### PR TITLE
Add image publisher to utils

### DIFF
--- a/src/pose_estimators/utils/image_publisher.py
+++ b/src/pose_estimators/utils/image_publisher.py
@@ -1,0 +1,17 @@
+import rospy
+from sensor_msgs.msg import Image
+
+
+class ImagePublisher(object):
+    """
+    A class which can subscribe to camera topics and publish detected images.
+    """
+    def __init__(self, node_name):
+        self.node_name = node_name
+        self.init_ros_publishers()
+
+    def init_ros_publishers(self):
+        self.pub_img = rospy.Publisher(
+            '{}/detection_image'.format(self.node_name),
+            Image,
+            queue_size=2)


### PR DESCRIPTION
Move the `image_publisher` from `food_detector` repo to the `pose_estimators/utils/`